### PR TITLE
remove JAX 2018

### DIFF
--- a/layouts/partials/footer_custom.html
+++ b/layouts/partials/footer_custom.html
@@ -9,12 +9,6 @@ Do not put anything in this file - it's only here so that hugo won't throw an er
     <h3 class="h4 text-center">The Eclipse Foundation will be attending these events - come meet us to find out more about Jakarta EE!</h3>
     <div class="row text-center">
       <div class="col-sm-12 col-md-6 event">
-        <h3 class="h4">JAX 2018</h3>
-        <p>Mainz, Germany</p>
-        <p>April 23-27, 2018</p>
-        <a class="btn btn-primary" href="https://jax.de/en/" target="_blank">Learn More</a>
-      </div>
-      <div class="col-sm-12 col-md-6 event">
         <h3 class="h4">KubeCon Europe 2018</h3>
         <p>Copenhagen, Denmark</p>
         <p>May 2-4, 2018</p>
@@ -32,14 +26,12 @@ Do not put anything in this file - it's only here so that hugo won't throw an er
         <p>June 13-14, 2018</p>
         <a class="btn btn-primary" href="https://www.eclipsecon.org/france2018/registration">Register Now</a>
       </div>
-      <!-- 
       <div class="col-sm-12 col-md-6 event">
         <h3 class="h4">EclipseCon Europe 2018</h3>
         <p>Ludwigsburg, Germany</p>
         <p>October 23-25, 2018</p>
         <a class="btn btn-primary" href="https://www.eclipsecon.org/europe2018">Learn More</a>
       </div>
-      -->
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adding EclipseCon Europe 2018.

Signed-off-by: Christopher Guindon <chris.guindon@eclipse-foundation.org>