### PR TITLE
Fixed 'Become a Member' link

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -14,7 +14,7 @@
     </li>
     <li>
       <i class="fa fa-caret-right fa-fw"></i>
-      <a href="/members/" target="_self">Become a Member</a>
+      <a href="/membership/" target="_self">Become a Member</a>
     </li>
     <li>
       <i class="fa fa-caret-right fa-fw"></i>


### PR DESCRIPTION
Clicking the 'Become a Member' link in the sidebar currently results in a 404. This PR fixes the link URL.